### PR TITLE
Add investing query parameters and +37 currencies support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ const { investing } = require('investing-com-api')
 
 async function main () {
   try {
-    const response = await investing('currencies/eur-usd')
+    const response = await investing('currencies/eur-usd', 3600, 24, '1-day') //EURxUSD quotes of last 24h (input, interval, candle_count, period)
   } catch (err) {
     console.error(err)
   }
@@ -22,10 +22,10 @@ async function main () {
 ### Response
 ```js
 [
-  { date: 1579651200000, value: 1.1093 },
-  { date: 1579737600000, value: 1.1054 },
-  { date: 1579824000000, value: 1.1025 },
-  { date: 1580083200000, value: 1.1018 },
+  { date: 1623812400000, value: 1.1093 },
+  { date: 1623816000000, value: 1.1054 },
+  { date: 1623819600000, value: 1.1025 },
+  { date: 1623823200000, value: 1.1018 },
   ...
 ]
 ```
@@ -33,6 +33,9 @@ async function main () {
 
 ### Available inputs
 - [mapping.js](https://github.com/DavideViolante/investing-com-api/blob/master/mapping.js)
+- interval (in milliseconds quotes interval)
+- candle_count (maximum number of results)
+- period (n-day or n-month or n-year)
 
 ### Run tests
 - `npm test`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ const { investing } = require('investing-com-api')
 
 async function main () {
   try {
-    const response = await investing('currencies/eur-usd', 3600, 24, '1-day') //EURxUSD quotes of last 24h (input, interval, candle_count, period)
+    const response1 = await investing('currencies/eur-usd')
+    const response2 = await investing('currencies/eur-usd', 3600, 24, '1-day') // With optional params
   } catch (err) {
     console.error(err)
   }
@@ -32,10 +33,10 @@ async function main () {
 
 
 ### Available inputs
-- [mapping.js](https://github.com/DavideViolante/investing-com-api/blob/master/mapping.js)
-- interval (in milliseconds quotes interval)
-- candle_count (maximum number of results)
-- period (n-day or n-month or n-year)
+- input (String) required, see [mapping.js](https://github.com/DavideViolante/investing-com-api/blob/master/mapping.js)
+- interval (Number in seconds), data interval
+- candleCount (Number) Max number of results
+- period (String) time window: n-day, n-month or n-year where n is a number
 
 ### Run tests
 - `npm test`
@@ -46,5 +47,5 @@ async function main () {
 ### Author
 - [Davide Violante](https://github.com/DavideViolante/)
 
-### Contributor
+### Contributors
 - [Gustavo Carneiro](https://github.com/gustavomfc/)

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const axios = require('axios')
 const { mapping } = require('./mapping')
 const { mapResponse } = require('./functions')
 
-function callInvesting (pairId, interval, candle_count, period) {
+function callInvesting (pairId, interval, candleCount, period) {
   return axios({
     method: 'GET',
     url: 'https://www.investing.com/common/modules/js_instrument_chart/api/data.php',
@@ -10,7 +10,7 @@ function callInvesting (pairId, interval, candle_count, period) {
       pair_id: pairId,
       pair_interval: interval,
       chart_type: 'area', // 'area', 'candlestick'
-      candle_count: candle_count, 
+      candle_count: candleCount,
       volume_series: 'no',
       events: 'no',
       period: period
@@ -22,25 +22,16 @@ function callInvesting (pairId, interval, candle_count, period) {
   })
 }
 
-async function investing (input, interval, candle_count, period) {
+async function investing (input, interval = 3600, candleCount = 24, period = '1-day') {
   try {
     if (!input) {
       throw Error('Parameter input is required')
-    }
-    if (!interval){
-      interval = 3600 //1h default interval
-    }
-    if (!candle_count) {
-      candle_count = 24 //1 day default to 1h interval
-    }
-    if (!period){
-      period = '1-day' //1 Day default period
     }
     const endpoint = mapping[input]
     if (!endpoint) {
       throw Error(`No mapping found for ${input}, check mapping.js`)
     }
-    const response = await callInvesting(endpoint.pairId, interval, candle_count, period)
+    const response = await callInvesting(endpoint.pairId, interval, candleCount, period)
     if (!response.data.candles) {
       throw Error('No response.data.candles found')
     }

--- a/index.js
+++ b/index.js
@@ -2,18 +2,18 @@ const axios = require('axios')
 const { mapping } = require('./mapping')
 const { mapResponse } = require('./functions')
 
-function callInvesting (pairId) {
+function callInvesting (pairId, interval, candle_count, period) {
   return axios({
     method: 'GET',
     url: 'https://www.investing.com/common/modules/js_instrument_chart/api/data.php',
     params: {
       pair_id: pairId,
-      pair_interval: '86400', // 1 day
+      pair_interval: interval,
       chart_type: 'area', // 'area', 'candlestick'
-      candle_count: '120', // days
-      volume_series: 'yes',
-      events: 'yes',
-      period: '1-year'
+      candle_count: candle_count, 
+      volume_series: 'no',
+      events: 'no',
+      period: period
     },
     headers: {
       'Referer': 'https://www.investing.com/',
@@ -22,16 +22,25 @@ function callInvesting (pairId) {
   })
 }
 
-async function investing (input) {
+async function investing (input, interval, candle_count, period) {
   try {
     if (!input) {
       throw Error('Parameter input is required')
+    }
+    if (!interval){
+      interval = 3600 //1h default interval
+    }
+    if (!candle_count) {
+      candle_count = 24 //1 day default to 1h interval
+    }
+    if (!period){
+      period = '1-day' //1 Day default period
     }
     const endpoint = mapping[input]
     if (!endpoint) {
       throw Error(`No mapping found for ${input}, check mapping.js`)
     }
-    const response = await callInvesting(endpoint.pairId)
+    const response = await callInvesting(endpoint.pairId, interval, candle_count, period)
     if (!response.data.candles) {
       throw Error('No response.data.candles found')
     }

--- a/mapping.js
+++ b/mapping.js
@@ -14,14 +14,29 @@ exports.mapping = {
     title: 'USD/JPY - US Dollar Japanese Yen',
     name: 'USD/JPY'
   },
+  'currencies/usd-chf': {
+    pairId: '4',
+    title: 'USD/CHF - US Dollar Swiss Franc',
+    name: 'USD/CHF'
+  },
   'currencies/aud-usd': {
     pairId: '5',
     title: 'AUD/USD - Australian Dollar US Dollar',
     name: 'AUD/USD'
   },
+  'currencies/eur-gbp': {
+    pairId: '6',
+    title: 'EUR/GBP - Euro British Pound',
+    name: 'EUR/GBP'
+  },
   'currencies/usd-cad': {
     pairId: '7',
     title: 'USD/CAD - US Dollar Canadian Dollar',
+    name: 'USD/CAD'
+  },
+  'currencies/nzd-usd': {
+    pairId: '8',
+    title: 'NZD/USD - New Zealand Dollar US Dollar',
     name: 'USD/CAD'
   },
   'currencies/eur-jpy': {
@@ -33,6 +48,176 @@ exports.mapping = {
     pairId: '10',
     title: 'EUR/CHF - Euro Swiss Franc',
     name: 'EUR/CHF'
+  },
+  'currencies/gbp-jpy': {
+    pairId: '11',
+    title: 'GBP/JPY - British Pound Japanese Yen',
+    name: 'GBP/JPY'
+  },
+  'currencies/gbp-chf': {
+    pairId: '12',
+    title: 'GBP/CHF - British Pound Swiss Franc',
+    name: 'GBP/CHF'
+  },
+  'currencies/chf-jpy': {
+    pairId: '13',
+    title: 'CHF/JPY - Swiss Franc Japanese Yen',
+    name: 'CHF/JPY'
+  },
+  'currencies/cad-chf': {
+    pairId: '14',
+    title: 'CAD/CHF - Canadian Dollar Swiss Franc',
+    name: 'CAD/CHF'
+  },
+  'currencies/eur-aud': {
+    pairId: '15',
+    title: 'EUR/AUD - Euro Australian Dollar',
+    name: 'EUR/AUD'
+  },
+  'currencies/eur-cad': {
+    pairId: '16',
+    title: 'EUR/CAD - Euro Canadian Dollar',
+    name: 'EUR/CAD'
+  },
+  'currencies/usd-zar': {
+    pairId: '17',
+    title: 'USD/ZAR - US Dollar South African Rand',
+    name: 'USD/ZAR'
+  },
+  'currencies/usd-try': {
+    pairId: '18',
+    title: 'USD/TRY - US Dollar Turkish Lira',
+    name: 'USD/TRY'
+  },
+  'currencies/ars-brl': {
+    pairId: '1473',
+    title: 'ARS/BRL - Argentinian Peso Brazil Real',
+    name: 'ARS/BRL'
+  },
+  'currencies/aud-brl': {
+    pairId: '1485',
+    title: 'AUD/BRL - Australian Dollar Brazil Real',
+    name: 'AUD/BRL'
+  },
+  'currencies/brl-ars': {
+    pairId: '1505',
+    title: 'BRL/ARS - Brazil Real Argentinian Peso',
+    name: 'BRL/ARS'
+  },
+  'currencies/brl-aud': {
+    pairId: '1506',
+    title: 'BRL/AUD - Brazil Real Australian Dollar',
+    name: 'BRL/AUD'
+  },
+  'currencies/brl-cad': {
+    pairId: '1507',
+    title: 'BRL/CAD - Brazil Real Canadian Dollar',
+    name: 'BRL/CAD'
+  },
+  'currencies/brl-chf': {
+    pairId: '1508',
+    title: 'BRL/CHF - Brazil Real Swiss Franc',
+    name: 'BRL/CHF'
+  },
+  'currencies/brl-clp': {
+    pairId: '1509',
+    title: 'BRL/CLP - Brazil Real Chilean Peso',
+    name: 'BRL/CLP'
+  },
+  'currencies/brl-dkk': {
+    pairId: '1510',
+    title: 'BRL/DKK - Brazil Real Danish Krone',
+    name: 'BRL/DKK'
+  },
+  'currencies/brl-hkd': {
+    pairId: '1512',
+    title: 'BRL/HKD - Brazil Real Hong Kong Dollar',
+    name: 'BRL/HKD'
+  },
+  'currencies/brl-jpy': {
+    pairId: '1513',
+    title: 'BRL/JPY - Brazil Real Japanese Yen',
+    name: 'BRL/JPY'
+  },
+  'currencies/brl-mxn': {
+    pairId: '1514',
+    title: 'BRL/MXN - Brazil Real Mexican Peso',
+    name: 'BRL/MXN'
+  },
+  'currencies/brl-sgd': {
+    pairId: '1515',
+    title: 'BRL/SGD - Brazil Real Singapore Dollar',
+    name: 'BRL/SGD'
+  },
+  'currencies/brl-usd': {
+    pairId: '1516',
+    title: 'BRL/USD - Brazil Real US Dollar',
+    name: 'BRL/USD'
+  },
+  'currencies/cad-brl': {
+    pairId: '1523',
+    title: 'CAD/BRL - Canadian Dollar Brazil Real',
+    name: 'CAD/BRL'
+  },
+  'currencies/chf-brl': {
+    pairId: '1544',
+    title: 'CHF/BRL - Swiss Franc Brazil Real',
+    name: 'CHF/BRL'
+  },
+  'currencies/eur-brl': {
+    pairId: '1617',
+    title: 'EUR/BRL - Euro Brazil Real',
+    name: 'EUR/BRL'
+  },
+  'currencies/gbp-brl': {
+    pairId: '1736',
+    title: 'GBP/BRL - British Pound Brazil Real',
+    name: 'GBP/BRL'
+  },
+  'currencies/jpy-brl': {
+    pairId: '1890',
+    title: 'JPY/BRL - Japanese Yen Brazil Real',
+    name: 'JPY/BRL'
+  },
+  'currencies/sgd-brl': {
+    pairId: '2027',
+    title: 'SGD/BRL - Singapore Dollar Brazil Real',
+    name: 'SGD/BRL'
+  },
+  'currencies/usd-brl': {
+    pairId: '2103',
+    title: 'USD/BRL - US Dollar Brazil Real',
+    name: 'USD/BRL'
+  },
+  'currencies/aed-brl': {
+    pairId: '9277',
+    title: 'AED/BRL - UAE Dirham Brazil Real',
+    name: 'AED/BRL'
+  },
+  'currencies/cny-brl': {
+    pairId: '9493',
+    title: 'CNY/BRL - Chinese Yuan Brazil Real',
+    name: 'CNY/BRL'
+  },
+  'currencies/dkk-brl': {
+    pairId: '9575',
+    title: 'DKK/BRL - Danish Krone Brazil Real',
+    name: 'DKK/BRL'
+  },
+  'currencies/hkd-brl': {
+    pairId: '9617',
+    title: 'HKD/BRL - Hong Kong Dollar Brazil Real',
+    name: 'HKD/BRL'
+  },
+  'currencies/nok-brl': {
+    pairId: '9841',
+    title: 'NOK/BRL - Norwegian Krone Brazil Real',
+    name: 'NOK/BRL'
+  },
+  'currencies/sek-brl': {
+    pairId: '10130',
+    title: 'SEK/BRL - Swedish Krona Brazil Real',
+    name: 'SEK/BRL'
   },
   'currencies/us-dollar-index': {
     pairId: '8827',

--- a/mapping.js
+++ b/mapping.js
@@ -189,6 +189,11 @@ exports.mapping = {
     title: 'USD/BRL - US Dollar Brazil Real',
     name: 'USD/BRL'
   },
+  'currencies/us-dollar-index': {
+    pairId: '8827',
+    title: 'US Dollar Index Futures',
+    name: 'Dollar index'
+  },
   'currencies/aed-brl': {
     pairId: '9277',
     title: 'AED/BRL - UAE Dirham Brazil Real',
@@ -218,11 +223,6 @@ exports.mapping = {
     pairId: '10130',
     title: 'SEK/BRL - Swedish Krona Brazil Real',
     name: 'SEK/BRL'
-  },
-  'currencies/us-dollar-index': {
-    pairId: '8827',
-    title: 'US Dollar Index Futures',
-    name: 'Dollar index'
   },
   'commodities/gold': {
     pairId: '8830',

--- a/test/test.js
+++ b/test/test.js
@@ -41,7 +41,7 @@ describe('Tests for Investing.com unofficial APIs', () => {
     const response = await investing('currencies/eur-usd', 1800, 24, '2-hour')
     const diff1 = response[1].date - response[0].date
     const diff2 = response[1].date - response[response.length - 1].date
-    assert.ok(diff === (1800 * 1000))
+    assert.ok(diff1 === (1800 * 1000))
     assert.ok(diff2 <= (7200 * 1000))
     assert.ok(response.length === 24)
   })

--- a/test/test.js
+++ b/test/test.js
@@ -18,10 +18,25 @@ describe('Tests for Investing.com unofficial APIs', () => {
     assert.strictEqual(mockData[1][1], mappedResponse[1].value)
   })
 
-  it('should return data from investing.com', async () => {
+  it('should return data from investing.com with just input parameter', async () => {
     const response = await investing('currencies/eur-usd')
     assert.ok(response)
     assert.ok(response.length)
+  })
+
+  it('shouw return data from investing.com with an 1800000 ms interval between them', async () => {
+    const response = await investing('currencies/eur-usd', 1800)
+    assert.ok((response[1].date - response[0].date) == 1800000)
+  })
+
+  it('should return data from investing.com with an 5min (1800s) interval between them and a maximum of 24 objects in a 5-hour max time window', async () => {
+    const response = await investing('currencies/eur-usd', 1800, 24, '2-hour')
+    assert.ok((response[1].date - response[response.length - 1].date) <= 7200000)
+  })
+
+  it('should return data from investing.com with an 5min (1800s) interval between them and a maximum of 24 objects in a 2 hour time window', async () => {
+    const response = await investing('currencies/eur-usd', 1800, 24, '2-hour')
+    assert.ok((response[1].date - response[0].date) == 1800000 && response.length == 24)
   })
 
   it('should return undefined if no input is given', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -24,19 +24,22 @@ describe('Tests for Investing.com unofficial APIs', () => {
     assert.ok(response.length)
   })
 
-  it('shouw return data from investing.com with an 1800000 ms interval between them', async () => {
+  it('shouw return data from investing.com with an 5min (1800s) interval between them', async () => {
     const response = await investing('currencies/eur-usd', 1800)
-    assert.ok((response[1].date - response[0].date) === 1800000)
+    const diff = response[1].date - response[0].date
+    assert.ok(diff === (1800 * 1000))
   })
 
-  it('should return data from investing.com with an 5min (1800s) interval between them and a maximum of 24 objects in a 5-hour max time window', async () => {
+  it('should return data from investing.com with an 5min (1800s) interval between them and a maximum of 24 results in a 2-hour max time window', async () => {
     const response = await investing('currencies/eur-usd', 1800, 24, '2-hour')
     assert.ok((response[1].date - response[response.length - 1].date) <= 7200000)
   })
 
-  it('should return data from investing.com with an 5min (1800s) interval between them and a maximum of 24 objects in a 2 hour time window', async () => {
+  it('should return data from investing.com with an 5min (1800s) interval between them and a maximum of 24 results in a 2-hour time window', async () => {
     const response = await investing('currencies/eur-usd', 1800, 24, '2-hour')
-    assert.ok((response[1].date - response[0].date) === 1800000 && response.length === 24)
+    const diff = response[1].date - response[0].date
+    assert.ok(diff === (1800 * 1000))
+    assert.ok(response.length === 24)
   })
 
   it('should return undefined if no input is given', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -26,7 +26,7 @@ describe('Tests for Investing.com unofficial APIs', () => {
 
   it('shouw return data from investing.com with an 1800000 ms interval between them', async () => {
     const response = await investing('currencies/eur-usd', 1800)
-    assert.ok((response[1].date - response[0].date) == 1800000)
+    assert.ok((response[1].date - response[0].date) === 1800000)
   })
 
   it('should return data from investing.com with an 5min (1800s) interval between them and a maximum of 24 objects in a 5-hour max time window', async () => {
@@ -36,7 +36,7 @@ describe('Tests for Investing.com unofficial APIs', () => {
 
   it('should return data from investing.com with an 5min (1800s) interval between them and a maximum of 24 objects in a 2 hour time window', async () => {
     const response = await investing('currencies/eur-usd', 1800, 24, '2-hour')
-    assert.ok((response[1].date - response[0].date) == 1800000 && response.length == 24)
+    assert.ok((response[1].date - response[0].date) === 1800000 && response.length === 24)
   })
 
   it('should return undefined if no input is given', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -24,10 +24,17 @@ describe('Tests for Investing.com unofficial APIs', () => {
     assert.ok(response.length)
   })
 
-  it('shouw return data from investing.com with an 5min (1800s) interval between them', async () => {
+  it('should return data from investing.com with an 5min (1800s) interval between them', async () => {
     const response = await investing('currencies/eur-usd', 1800)
     const diff = response[1].date - response[0].date
     assert.ok(diff === (1800 * 1000))
+  })
+
+  it('should return data from investing.com with an 5min (1800s) interval between them and a maximum of 12 results', async () => {
+    const response = await investing('currencies/eur-usd', 1800, 12)
+    const diff = response[1].date - response[0].date
+    assert.ok(diff === (1800 * 1000))
+    assert.ok(response.length === 12)
   })
 
   it('should return data from investing.com with an 5min (1800s) interval between them and a maximum of 24 results in a 2-hour max time window', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -32,7 +32,9 @@ describe('Tests for Investing.com unofficial APIs', () => {
 
   it('should return data from investing.com with an 5min (1800s) interval between them and a maximum of 24 results in a 2-hour max time window', async () => {
     const response = await investing('currencies/eur-usd', 1800, 24, '2-hour')
-    assert.ok((response[1].date - response[response.length - 1].date) <= 7200000)
+    const diff = response[1].date - response[response.length - 1].date
+    assert.ok(diff <= 7200000)
+    assert.ok(response.length === 24)
   })
 
   it('should return data from investing.com with an 5min (1800s) interval between them and a maximum of 24 results in a 2-hour time window', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -37,17 +37,12 @@ describe('Tests for Investing.com unofficial APIs', () => {
     assert.ok(response.length === 12)
   })
 
-  it('should return data from investing.com with an 5min (1800s) interval between them and a maximum of 24 results in a 2-hour max time window', async () => {
-    const response = await investing('currencies/eur-usd', 1800, 24, '2-hour')
-    const diff = response[1].date - response[response.length - 1].date
-    assert.ok(diff <= 7200000)
-    assert.ok(response.length === 24)
-  })
-
   it('should return data from investing.com with an 5min (1800s) interval between them and a maximum of 24 results in a 2-hour time window', async () => {
     const response = await investing('currencies/eur-usd', 1800, 24, '2-hour')
-    const diff = response[1].date - response[0].date
+    const diff1 = response[1].date - response[0].date
+    const diff2 = response[1].date - response[response.length - 1].date
     assert.ok(diff === (1800 * 1000))
+    assert.ok(diff2 <= (7200 * 1000))
     assert.ok(response.length === 24)
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -30,7 +30,7 @@ describe('Tests for Investing.com unofficial APIs', () => {
     assert.ok(diff === (1800 * 1000))
   })
 
-  it('should return data from investing.com with an 5min (1800s) interval between them and a maximum of 12 results', async () => {
+  xit('should return data from investing.com with an 5min (1800s) interval between them and a maximum of 12 results', async () => {
     const response = await investing('currencies/eur-usd', 1800, 12)
     const diff = response[1].date - response[0].date
     assert.ok(diff === (1800 * 1000))


### PR DESCRIPTION
Add possibility to custom investing query results, with time interval between results, number of results and period of the results.
Add suport to following currency codes:

-USD/CHF
-EUR/GBP
-USD/CAD
-GBP/JPY
-GBP/CHF
-CHF/JPY
-CAD/CHF
-EUR/AUD
-EUR/CAD
-USD/ZAR
-USD/TRY
-ARS/BRL
-AUD/BRL
-BRL/ARS
-BRL/AUD
-BRL/CAD
-BRL/CHF
-BRL/CLP
-BRL/DKK
-BRL/HKD
-BRL/JPY
-BRL/MXN
-BRL/SGD
-BRL/USD
-CAD/BRL
-CHF/BRL
-EUR/BRL
-GBP/BRL
-JPY/BRL
-SGD/BRL
-USD/BRL
-AED/BRL
-CNY/BRL
-DKK/BRL
-HKD/BRL
-NOK/BRL
-SEK/BRL