### PR TITLE
Add extra price data into the response object

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -10,7 +10,7 @@ function mapResponse(array) {
     price_open: item[1],
     price_high: item[2],
     price_low: item[3],
-    price_close: item[4]
+    price_close: item[4],
   }));
 }
 

--- a/functions.js
+++ b/functions.js
@@ -5,8 +5,12 @@
  */
 function mapResponse(array) {
   return array.map((item) => ({
-    date: item[0],
-    value: item[1],
+    date: item[0], // date
+    value: item[1], // open
+    price_open: item[1],
+    price_high: item[2],
+    price_low: item[3],
+    price_close: item[4]
   }));
 }
 


### PR DESCRIPTION
Hi all,

I noticed when hitting the API in my browser that the JSON object that's being returned has some "extra" price data that we could perhaps be including.

</br>

**Context**

In the function.js file we're assigning value=item[1], but there's also item[2], item[3] and item[4] that seem to hold some relevant values too.

As an example, I made the following request to the API (23869=[Australia 1-Year Bond Yield](https://www.investing.com/rates-bonds/australia-1-year-bond-yield-historical-data)):
https://api.investing.com/api/financialdata/23869/historical/chart/?period=P1M&interval=P1D&pointscount=120

The returned response (screenshot below) has the date, and then four (4) numeric values that seem relevant, along with two trailing zeros which I'm assuming are only utilised in some special cases / specific API requests?

<img width="470" alt="image" src="https://user-images.githubusercontent.com/29676223/181725980-52cf0aa3-c9db-4bbb-95f6-8bd0afdfa7f9.png">

If we just focus on a single item here (the item in the red-box), we can convert the UNIX time to figure out that this item relates to the Australia 1-Year Bond Yield on the 14th of July, 2022.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/29676223/181727055-9cae2ebc-5ec4-47d7-bd52-7cf79e0819e2.png">

Then, if we look on the investing.com historical data we can find that on July 14 that we also have four (4) relevant values:

<img width="470" alt="image" src="https://user-images.githubusercontent.com/29676223/181727728-04352582-3863-4ac4-953f-f537797c5d93.png">

- Price: 2.525
- Open: 2.413
- High: 2.563
- Low: 2.368

Now, if we compare these values to the response (that was surrounded in the red-box in the first screenshot) we can get an idea of what each value represents:

- Price: 2.525 -> item[4]
- Open: 2.413 -> item[1]
- High: 2.563 -> item[2]
- Low: 2.368 -> item[3]

This means that when we are referring to "value" it seems like what we're actually referring to the "open price." 

It's interesting that item[4] is simply referred to as "Price" on the website, which doesn't really tell us much.

However, I did a bit of extra due-diligence, and if we compare the investing.com data that we're querying with something like finance.yahoo.com (using the same ticker) then we can see that this "Price" value seems to match the close / adjusted-close value in this case (screenshots below). 

<img width="470" alt="image" src="https://user-images.githubusercontent.com/29676223/181730277-8624ace8-409f-4107-80b6-1844a62e5e35.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/29676223/181730482-fcf9b95b-5ffc-42e2-ba2f-5436d75bfa0c.png">

It's difficult to determine if item[4] represents the close or the adjusted-close value, but I think we can be quite confident that this "Price" value is referring to some sort of close-related-value (but, whether it's close, adjusted-close, or some different "investing.com spin on close" is unknown). 

</br>

**Solution**

In my very simple proposed solution (this commit) I've opted to keep the `date` and `value` keys, because changing the name of those would certainly affect people who are already utilising this package.

Then, I've then simply just added all the other extra price values into the function that maps through all the items within the API response (I consciously made the choice to repeat `item[1]`, in an effort to be explicit).

```
function mapResponse(array) {
  return array.map((item) => ({
    date: item[0], // date
    value: item[1], // open
    price_open: item[1],
    price_high: item[2],
    price_low: item[3],
    price_close: item[4]
  }));
}
```

However, a better way to implement this would likely be to set some sort of boolean parameter in the `index.js`, and when it's set to `true` the package should then use this "extended version" of the `mapResponse` function. Something like...

```
@param {boolean} include_extra_prices
```

Followed by...

```
function mapResponse(array) {
  if (include_extra_prices === true) {
    return array.map((item) => ({
      date: item[0], // date
      value: item[1], // open
      price_open: item[1],
      price_high: item[2],
      price_low: item[3],
      price_close: item[4]
  } else {
    return array.map((item) => ({
      date: item[0],
      value: item[1],
  }
  }));
}
```

I doubt the above would even be the correct javascript, I'm sure there would need to be a lot more changes, but I'm just spit-balling solutions and trying to showcase my thinking. 

The idea would be that, if we added some sort of parameter like this, that defaults to `False`, then it would essentially leave the people who don't care about this extra completely unaffected by the change - but it would give people who might want to utilise this extra price data the option to do so.

I know my simple solution, and my idea for this "parameter-based solution" might not be the best, and there likely will be an even better solution - but I just wanted to start some discussion / suggestions - especially before I went ahead and tried to implement something a bit more complicated!

I'm completely new to javascript, contributing, and all the rest of it - so I'm definitely keen to solve this problem - I just might need a bit of nudging towards what would be "best practice" in javascript here! 😁

Cheers,
Troy

